### PR TITLE
Feature/#1-api-gateway-filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/f4/apigateway/config/AppConfig.java
+++ b/src/main/java/f4/apigateway/config/AppConfig.java
@@ -1,0 +1,13 @@
+package f4.apigateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+  @Bean
+  public RestTemplate template() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/f4/apigateway/constant/OpenApiEndpoints.java
+++ b/src/main/java/f4/apigateway/constant/OpenApiEndpoints.java
@@ -1,0 +1,24 @@
+package f4.apigateway.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public enum OpenApiEndpoints {
+  REGISTER("/auth/v1/register", "회원가입 API"),
+  LOGIN("/auth/v1/login", "로그인 API"),
+  EUREKA("/eureka", "Eureka 서비스"),
+  EMAIL_SEND("/email/v1/send", "이메일 인증 코드 발송 API");
+
+  private final String path;
+  private final String description;
+
+  public static List<String> allPaths() {
+    return Arrays.stream(values()).map(OpenApiEndpoints::getPath).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/f4/apigateway/exception/CustomErrorCode.java
+++ b/src/main/java/f4/apigateway/exception/CustomErrorCode.java
@@ -1,0 +1,13 @@
+package f4.apigateway.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+    MISSING_AUTHORIZATION_HEADER(402, "요청에 Authorization 헤더가 없습니다."),
+    UN_AUTHORIZED_ACCESS_TO_APPLICATION(401, "인증받은 토큰이 아닙니다.");
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/f4/apigateway/exception/CustomException.java
+++ b/src/main/java/f4/apigateway/exception/CustomException.java
@@ -1,0 +1,13 @@
+package f4.apigateway.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final CustomErrorCode customErrorCode;
+
+    public CustomException(CustomErrorCode customErrorCode) {
+        super(customErrorCode.getMessage());
+        this.customErrorCode = customErrorCode;
+    }
+}

--- a/src/main/java/f4/apigateway/exception/ErrorDetails.java
+++ b/src/main/java/f4/apigateway/exception/ErrorDetails.java
@@ -1,0 +1,14 @@
+package f4.apigateway.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ErrorDetails {
+
+  private int code;
+  private String message;
+}

--- a/src/main/java/f4/apigateway/exception/GlobalExceptionHandler.java
+++ b/src/main/java/f4/apigateway/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package f4.apigateway.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler({CustomException.class})
+  public ResponseEntity<?> customExceptionHandler(CustomException e) {
+    log.error(
+        "errorCode: {}, message: {}",
+        e.getCustomErrorCode().getCode(),
+        e.getCustomErrorCode().getMessage());
+
+    return new ResponseEntity<>(
+        ErrorDetails.builder()
+            .code(e.getCustomErrorCode().getCode())
+            .message(e.getCustomErrorCode().getMessage())
+            .build(),
+        HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/f4/apigateway/filter/AuthenticationFilter.java
+++ b/src/main/java/f4/apigateway/filter/AuthenticationFilter.java
@@ -1,0 +1,52 @@
+package f4.apigateway.filter;
+
+import f4.apigateway.exception.CustomErrorCode;
+import f4.apigateway.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
+  private final RouteValidator validator;
+  private final RestTemplate template;
+
+  @Override
+  public GatewayFilter apply(Config config) {
+    return (exchange, chain) -> {
+      if (shouldValidateRequest(exchange.getRequest())) {
+        String token = extractTokenFromRequest(exchange.getRequest());
+        validateToken(token);
+      }
+      return chain.filter(exchange);
+    };
+  }
+
+  private boolean shouldValidateRequest(ServerHttpRequest request) {
+    return validator.isSecured.test(request) && !request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION);
+  }
+
+  private String extractTokenFromRequest(ServerHttpRequest request) {
+    String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      throw new CustomException(CustomErrorCode.MISSING_AUTHORIZATION_HEADER);
+    }
+    return authHeader.substring(7);
+  }
+
+  private void validateToken(String token) {
+    try {
+      template.getForObject("http://AUTH-SERVICE/validate?token=" + token, String.class);
+    } catch (Exception e) {
+      throw new CustomException(CustomErrorCode.UN_AUTHORIZED_ACCESS_TO_APPLICATION);
+    }
+  }
+
+  public static class Config {}
+}

--- a/src/main/java/f4/apigateway/filter/RouteValidator.java
+++ b/src/main/java/f4/apigateway/filter/RouteValidator.java
@@ -1,0 +1,15 @@
+package f4.apigateway.filter;
+
+import f4.apigateway.constant.OpenApiEndpoints;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Predicate;
+
+@Component
+public class RouteValidator {
+  public Predicate<ServerHttpRequest> isSecured =
+      request ->
+          OpenApiEndpoints.allPaths().stream()
+              .noneMatch(uri -> request.getURI().getPath().contains(uri));
+}


### PR DESCRIPTION
[CustomErrorCode]
- 402 = 요청에 Authorization 헤더가 없습니다.
- 401 = 인증받은 토큰이 아닙니다.

[ErrorDetails]
에러 코드와 메세지만 사용함.

api-gateway filter코드 구현함.
auth-service의 validate api를 요청하여 검증할 예정이며, 추후 auth-service가 user-service로부터 분리되어 나오면 테스트할 예정.
RouteValidater를 이용하여, api-gateway의 필터에서 제외시키는 api를 작성하였음.
- REGISTER("/auth/v1/register", "회원가입 API"),
- LOGIN("/auth/v1/login", "로그인 API"),
- EUREKA("/eureka", "Eureka 서비스"),
- EMAIL_SEND("/email/v1/send", "이메일 인증 코드 발송 API")